### PR TITLE
Responsive UX Pass: Right-Side Mobile Drawer, Synced Breakpoints, and Site-Wide Polish

### DIFF
--- a/src/components/DisclaimerSection/DisclaimerSection.module.css
+++ b/src/components/DisclaimerSection/DisclaimerSection.module.css
@@ -4,11 +4,18 @@
   justify-content: center;
   gap: 8px;
   margin-bottom: 8px;
+}
 
-  >img{
-    height: 32px;
-    width: auto;
-  }
+.titleRow > img {
+  height: 32px;
+  width: auto;
+}
+
+/* Explicit class for the logo image to ensure styles apply reliably */
+.navbarLogo {
+  height: 32px;
+  width: auto;
+  display: inline-block;
 }
 
 .disclaimerSection {

--- a/src/components/QuickLinks/QuickLinks.module.css
+++ b/src/components/QuickLinks/QuickLinks.module.css
@@ -20,10 +20,17 @@
 
 .tilesContainer {
   display: flex;
+  flex-direction: row;
   flex-wrap: wrap;
   justify-content: center;
   gap: 32px;
   padding: 0 16px;
+}
+
+@media (min-width: 1200px) {
+  .tilesContainer {
+    flex-wrap: nowrap;
+  }
 }
 
 .tile {

--- a/src/pages/ShowcaseCards.tsx
+++ b/src/pages/ShowcaseCards.tsx
@@ -37,7 +37,9 @@ export default function ShowcaseCards({
       <div
         className={noGrid ? undefined : styles.showcaseCards}
         style={
-          noGrid ? { display: "flex", flexDirection: "column" } : undefined
+          noGrid
+            ? { display: "flex", flexDirection: "column", alignItems: "center" }
+            : undefined
         }
       >
         {filteredUsers

--- a/src/pages/styles.module.css
+++ b/src/pages/styles.module.css
@@ -9,6 +9,10 @@
 
 .viewButtons {
   display: flex;
+  width: 83px;
+  min-width: 83px;
+  max-width: 83px;
+  flex: 0 0 83px;
 }
 
 .viewButtons {
@@ -27,6 +31,8 @@
   align-items: center;
   font-size: 20px;
   transition: background 0.2s;
+  flex: 1 1 0;
+  justify-content: center;
 }
 .iconButton:first-child {
   border-top-left-radius: 4px;
@@ -66,6 +72,24 @@
   font-size: 18px !important;
   font-weight: 400 !important;
   color: #605e5c;
+}
+
+/* Center Resource Library heading + description on smaller screens */
+@media screen and (max-width: 960px) {
+  .titleSection {
+    width: 100%;
+    margin: 0 auto;
+    align-items: center;
+    text-align: center;
+  }
+
+  .resourceTitle {
+    text-align: center;
+  }
+
+  .centeredDescription {
+    text-align: center !important;
+  }
 }
 
 .checkboxList {
@@ -134,6 +158,7 @@
     grid-template-columns: minmax(240px, 1fr);
     max-width: 100%;
     gap: 20px;
+    justify-items: center;
   }
 }
 


### PR DESCRIPTION
## Overview
This PR delivers a comprehensive responsiveness and navigation update aligned with Microsoft design guidance. It modernizes the mobile experience with a right-hand hamburger menu and drawer, centers key UI elements on small screens, enforces consistent spacing, and resolves several visual and functional issues.

---

## Changes

### 🍔 Navigation
- **Hamburger toggle** moved to the right with icon color `#565555`
- **Mobile drawer** slides in from the right with Fluent-style surface, rounded links, and clear hover/active states
- **Complete navigation structure** in drawer:
  - Home
  - Learning Paths
  - Resource Library (Documentation, Solution Accelerators, Videos, Blogs, Trainings, Samples)
  - Quick Links
  - Community & Support
- **Close button** refined to 18px icon with 4px padding and subtle hover effect
- **Synced breakpoints**: navbar center hidden at 996px (matches hamburger), eliminating transition mismatch

### 💬 Floating Feedback CTA
- New **floating "Share Feedback" button** positioned 16px from the right edge
- Appears at ≤996px breakpoint, matching hamburger timing
- Currently **disabled** pending activation
- Navbar feedback button hidden on small screens to prevent duplication

### 📚 Resource Library
- **Sticky filter panel** on wide screens; switches to stacked layout below 960px
- Title and description **centered** on ≤960px
- Grid maintains **3/2/1 column layout** responsively; single-column cards auto-center
- **View toggle container** fixed at 83px width to preserve layout symmetry when title wraps

### ⭐ Featured Resources
- Single featured card **centers** on screens ≤768px (noGrid path)

### 🔗 Quick Links
- Default tile layout displays as a **row**
- **No wrapping** on screens ≥1200px
- Responsive spacing and wrapping maintained below 1200px

### 🏷️ Badges
- Removed per-tag color mapping logic
- All tag badges use **blue ("informative")** styling
- "+X more" badges use **grey ("subtle")** styling

### 🖼️ Images
- Fixed `OptimizedImage` path conversion to properly resolve `/img-optimized/` for both absolute and relative paths
- Ensures WebP variants load correctly with proper fallback logic

### 🔖 Disclaimer
- Replaced nested selector with explicit `.navbarLogo` and `.titleRow > img` rules
- Ensures consistent behavior across dev and serve builds

### 📏 Spacing
- Enforced **16px horizontal gutters** for navbar at widths <1024px throughout the site

---

## Implementation Notes
- Mobile drawer styling and right-side animation implemented via CSS overrides of `.navbar-sidebar` and `.navbar-sidebar--show`
- Mobile menu fallback populates links when `themeConfig.navbar.items` lacks standard items
- Floating CTA rendered in Root component, visibility controlled purely by CSS media queries to match hamburger timing

---

## Testing Performed
- ✅ Mobile nav behavior verified at key breakpoints (≥996px, <996px, <768px)
- ✅ Drawer link actions confirmed (scroll + tag filtering) for Resource Library
- ✅ Featured and Resource Library card centering validated on mobile
- ✅ Quick Links row behavior and nowrap confirmed on ≥1200px
- ✅ Badge colors and tooltip behavior verified
- ✅ WebP srcset generation and fallback image loading validated
- ✅ Disclaimer logo sizing confirmed in both dev and serve modes

---

## Risk & Impact
- **Visual/CSS-only changes** across navigation and responsive layouts
- **Low risk**: No API changes or breaking functionality
- Drawer CSS overrides depend on Docusaurus classnames (`.navbar-sidebar`, `.navbar-sidebar--show`)

---

## Rollback Plan
Revert this commit to restore:
- Default left-slide mobile drawer
- Previous spacing and color schemes
- Original image path resolution logic

---

## Checklist
- [x] Right-side hamburger + right-side drawer
- [x] Complete drawer links and Fluent styling
- [x] Floating feedback CTA (disabled), 16px from right edge
- [x] 16px navbar gutters for <1024px; synced 996px breakpoints
- [x] Centered Featured/Resource cards on mobile
- [x] Quick Links row layout with nowrap ≥1200px
- [x] Simplified badge color system
- [x] Fixed `OptimizedImage` path resolution
- [x] Reliable Disclaimer logo CSS

---

## Notes
This PR can be split into separate PRs (navigation, responsiveness, image handling) if preferred for easier review and deployment.