### PR TITLE
ci: bump Node.js to 20.x in GitHub Actions workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: yarn
 
       - name: Install dependencies

--- a/.github/workflows/optimize-and-deploy.yml
+++ b/.github/workflows/optimize-and-deploy.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
           
       - name: Install dependencies


### PR DESCRIPTION
## Description

This PR updates the Node.js runtime environment in our GitHub Actions workflows from version 18 to **Node 20**. This is a mandatory update to satisfy the minimum requirements for the latest Docusaurus dependencies.

**Status:** ✅ Ready for Review

## 📋 Key Changes

  * **Workflow Update:** Modified `deploy.yml` (and `optimize-and-deploy.yml` where applicable) to use `node-version: 20`.
  * **Environment Alignment:** Ensures CI uses the same major Node version required by `package.json` engines.

## 🧐 Why?

The build pipeline was failing with the following error:

> `Error: Minimum Node.js version not met — Requirement: Node.js >= 20.0`

Docusaurus and its modern plugins have dropped support for Node 18. Upgrading to Node 20 restores our ability to run `npm install` and `npm run build` successfully in the CI environment.

## 🧪 How to Test

1.  **Local Validation:** Switch your local environment to Node 20 and verify the build still passes:
    ```bash
    nvm use 20  # or install Node 20
    npm install
    npm run build
    ```
2.  **CI Validation:** Once this PR is merged (or if you look at the checks tab for this branch), GitHub Actions should execute the `setup-node` step with version 20 and the build step should succeed.

## ⚠️ Notes for Reviewers

  * **Version Pinning:** We are using `20.x` to get the latest security patches for Node 20 automatically.
  * **Compatibility:** If you encounter issues locally, please ensure you have updated your local Node version.

-----
