### PR TITLE
🔄 Improve Share Feedback Experience with GitHub Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feedback.md
+++ b/.github/ISSUE_TEMPLATE/feedback.md
@@ -1,0 +1,42 @@
+---
+name: Feedback
+about: Share feedback about the PostgreSQL Gallery
+title: '[FEEDBACK] '
+labels: feedback
+assignees: ''
+
+---
+
+## Type of Feedback
+<!-- Please check the type of feedback you're providing -->
+- [ ] Bug report
+- [ ] Feature request
+- [ ] Content suggestion
+- [ ] General feedback
+- [ ] Other
+
+## Description
+<!-- Please provide a clear and concise description of your feedback -->
+
+## Steps to Reproduce (for bug reports)
+<!-- If reporting a bug, please describe the steps to reproduce the issue -->
+1. 
+2. 
+3. 
+
+## Expected Behavior
+<!-- What did you expect to happen? -->
+
+## Actual Behavior
+<!-- What actually happened? -->
+
+## Additional Context
+<!-- Add any other context about the feedback here, such as screenshots, environment details, etc. -->
+
+## Browser Information (if applicable)
+- Browser: [e.g. Chrome, Firefox, Safari]
+- Version: [e.g. 22]
+- OS: [e.g. iOS, Windows, Mac]
+
+## Additional Comments
+<!-- Any other information you'd like to share -->

--- a/.github/ISSUE_TEMPLATE/feedback.md
+++ b/.github/ISSUE_TEMPLATE/feedback.md
@@ -41,9 +41,12 @@ assignees: ""
 
 <!-- What actually happened? -->
 
-## Screenshots
+## Screenshots / Screen Recordings
 
-<!-- If applicable, add screenshots to help explain your problem -->
+<!-- If applicable, add screenshots or screen recordings to help explain your problem -->
+<!-- For screen recordings, you can drag and drop MP4, MOV, or WebM files directly into GitHub -->
+<!-- Consider using tools like OBS Studio, QuickTime (Mac), or Windows Game Bar for recording -->
+<!-- Max file size: 10MB per file -->
 
 ## Device Information
 

--- a/.github/ISSUE_TEMPLATE/feedback.md
+++ b/.github/ISSUE_TEMPLATE/feedback.md
@@ -1,14 +1,15 @@
 ---
 name: Feedback
 about: Share feedback about the PostgreSQL Gallery
-title: '[FEEDBACK] '
+title: "[FEEDBACK] "
 labels: feedback
-assignees: ''
-
+assignees: ""
 ---
 
 ## Type of Feedback
+
 <!-- Please check the type of feedback you're providing -->
+
 - [ ] Bug report
 - [ ] Feature request
 - [ ] Content suggestion
@@ -16,27 +17,53 @@ assignees: ''
 - [ ] Other
 
 ## Description
+
 <!-- Please provide a clear and concise description of your feedback -->
 
+## Describe the Bug (if reporting a bug)
+
+<!-- A clear and concise description of what the bug is -->
+
 ## Steps to Reproduce (for bug reports)
-<!-- If reporting a bug, please describe the steps to reproduce the issue -->
-1. 
-2. 
-3. 
+
+<!-- Steps to reproduce the behavior -->
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
 
 ## Expected Behavior
-<!-- What did you expect to happen? -->
+
+<!-- A clear and concise description of what you expected to happen -->
 
 ## Actual Behavior
+
 <!-- What actually happened? -->
 
-## Additional Context
-<!-- Add any other context about the feedback here, such as screenshots, environment details, etc. -->
+## Screenshots
 
-## Browser Information (if applicable)
-- Browser: [e.g. Chrome, Firefox, Safari]
+<!-- If applicable, add screenshots to help explain your problem -->
+
+## Device Information
+
+**Desktop (please complete the following information):**
+
+- OS: [e.g. Windows, macOS, Linux]
+- Browser: [e.g. Chrome, Firefox, Safari, Edge]
 - Version: [e.g. 22]
-- OS: [e.g. iOS, Windows, Mac]
+
+**Smartphone (please complete the following information):**
+
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Browser: [e.g. stock browser, safari]
+- Version: [e.g. 22]
+
+## Additional Context
+
+<!-- Add any other context about the problem here, such as error messages, network conditions, etc. -->
 
 ## Additional Comments
+
 <!-- Any other information you'd like to share -->

--- a/src/utils/githubUtils.ts
+++ b/src/utils/githubUtils.ts
@@ -4,7 +4,7 @@
  */
 export const openGitHubNewIssue = (issuesUrl?: string): void => {
   const defaultUrl =
-    "https://github.com/AzureCosmosDB/gallery/issues/new?template=feedback.md";
+    "https://github.com/EmumbaOrg/postgres-gallery/issues/new?template=feedback.md";
   window.open(issuesUrl || defaultUrl, "_blank");
 };
 

--- a/src/utils/githubUtils.ts
+++ b/src/utils/githubUtils.ts
@@ -1,18 +1,18 @@
 /**
- * Utility function to open GitHub issues page in a new tab
- * @param issuesUrl - Optional GitHub issues URL, defaults to the postgres-appdev-hub issues page
+ * Utility function to open GitHub new issue page with feedback template in a new tab
+ * @param issuesUrl - Optional GitHub new issue URL, defaults to the gallery repository new issue page with feedback template
  */
-export const openGitHubIssues = (issuesUrl?: string): void => {
+export const openGitHubNewIssue = (issuesUrl?: string): void => {
   const defaultUrl =
-    "https://github.com/Azure-Samples/postgres-appdev-hub/issues";
+    "https://github.com/AzureCosmosDB/gallery/issues/new?template=feedback.md";
   window.open(issuesUrl || defaultUrl, "_blank");
 };
 
 /**
- * Higher-order function to create a click handler that opens GitHub issues
- * @param issuesUrl - Optional GitHub issues URL, defaults to the postgres-appdev-hub issues page
+ * Higher-order function to create a click handler that opens GitHub new issue page with template
+ * @param issuesUrl - Optional GitHub new issue URL, defaults to the gallery repository new issue page with feedback template
  * @returns A click handler function
  */
 export const shareFeedbackHandler = (issuesUrl?: string) => {
-  return () => openGitHubIssues(issuesUrl);
+  return () => openGitHubNewIssue(issuesUrl);
 };


### PR DESCRIPTION
## 📋 Summary
Enhanced the "Share Feedback" functionality to direct users to a pre-filled GitHub issue creation page with a structured feedback template, replacing the previous behavior that only showed the general issues list.

## 🎯 Motivation
Previously, when users clicked "Share Feedback", they were taken to the general GitHub issues page where they had to manually create an issue without any guidance. This often resulted in:
- Inconsistent feedback format
- Missing important information
- Users abandoning the feedback process due to lack of structure
- Harder triage process for maintainers

## ✨ Changes Made

### 1. Created GitHub Issue Template
- **File**: `.github/ISSUE_TEMPLATE/feedback.md`
- **Features**:
  - Structured feedback form with checkboxes for feedback type (bug, feature request, content suggestion, etc.)
  - Guided sections for bug reproduction steps
  - Browser and environment information fields
  - Clear sections for expected vs actual behavior
  - Additional context and comments section

### 2. Updated Feedback Handler
- **File**: `src/utils/githubUtils.ts`
- **Changes**:
  - Updated repository URL from `postgres-appdev-hub` to correct `AzureCosmosDB/gallery`
  - Modified URL to point to new issue creation with template parameter
  - Renamed functions for clarity: `openGitHubIssues` → `openGitHubNewIssue`
  - Updated function documentation and comments

## 🔗 New User Flow
1. User clicks "Share Feedback" (floating button or navbar)
2. Opens new tab to: `https://github.com/AzureCosmosDB/gallery/issues/new?template=feedback.md`
3. GitHub pre-fills the issue with the feedback template
4. User fills out structured form with guided prompts
5. Submits well-formatted feedback

## 🧪 How to Test
1. Build and run the application locally
2. Click the "Share Feedback" floating button (bottom-right corner)
3. Verify it opens GitHub's new issue page with the feedback template pre-loaded
4. Test the navbar "Share Feedback" button as well
5. Confirm both buttons redirect to the same templated new issue page

## 📸 Expected Behavior
- **Before**: Clicking feedback button → GitHub issues list page
- **After**: Clicking feedback button → GitHub new issue page with feedback template

## 🎉 Benefits
- **Improved UX**: Users get guided prompts for better feedback
- **Consistent Data**: All feedback follows the same structured format
- **Better Triage**: Maintainers can process feedback more efficiently
- **Higher Completion Rate**: Users less likely to abandon feedback process
- **Correct Repository**: Feedback now goes to the right repository

## 🔍 Files Modified
- `.github/ISSUE_TEMPLATE/feedback.md` (new)
- `src/utils/githubUtils.ts` (modified)

## 🏷️ Type of Change
- [x] Enhancement
- [x] User Experience Improvement
- [ ] Bug Fix
- [ ] Breaking Change
- [ ] Documentation Update