### PR TITLE
Add spacing for main category accordion items in MobileFilterDrawer and ShowcaseLeftFilters

### DIFF
--- a/src/components/gallery/MobileFilterDrawer/index.tsx
+++ b/src/components/gallery/MobileFilterDrawer/index.tsx
@@ -121,8 +121,9 @@ export default function MobileFilterDrawer({
     (tag) => Tags[tag]?.type === "ContentType",
   );
   const resourceTypeTags = TagList.filter(
-    (tag) => Tags[tag]?.type === "ResourceType" && 
-             !['concepts', 'how-to', 'tutorial'].includes(tag)
+    (tag) =>
+      Tags[tag]?.type === "ResourceType" &&
+      !["concepts", "how-to", "tutorial"].includes(tag),
   );
   const languageTags = TagList.filter((tag) => Tags[tag]?.type === "Language");
 
@@ -210,7 +211,10 @@ export default function MobileFilterDrawer({
                 </AccordionPanel>
               </AccordionItem>
               {/* Pathways */}
-              <AccordionItem value="1" className={styles.sortSection}>
+              <AccordionItem
+                value="1"
+                className={`${styles.sortSection} ${styles.mainCategoryItem}`}
+              >
                 <AccordionHeader
                   expandIconPosition="end"
                   className={styles.accordionHeader}
@@ -235,7 +239,10 @@ export default function MobileFilterDrawer({
               </AccordionItem>
 
               {/* Products */}
-              <AccordionItem value="2" className={styles.sortSection}>
+              <AccordionItem
+                value="2"
+                className={`${styles.sortSection} ${styles.mainCategoryItem}`}
+              >
                 <AccordionHeader
                   expandIconPosition="end"
                   className={styles.accordionHeader}
@@ -304,7 +311,10 @@ export default function MobileFilterDrawer({
               </AccordionItem>
 
               {/* Resource Type */}
-              <AccordionItem value="3" className={styles.sortSection}>
+              <AccordionItem
+                value="3"
+                className={`${styles.sortSection} ${styles.mainCategoryItem}`}
+              >
                 <AccordionHeader
                   expandIconPosition="end"
                   className={styles.accordionHeader}
@@ -373,7 +383,10 @@ export default function MobileFilterDrawer({
               </AccordionItem>
 
               {/* Category */}
-              <AccordionItem value="4" className={styles.sortSection}>
+              <AccordionItem
+                value="4"
+                className={`${styles.sortSection} ${styles.mainCategoryItem}`}
+              >
                 <AccordionHeader
                   expandIconPosition="end"
                   className={styles.accordionHeader}
@@ -398,7 +411,10 @@ export default function MobileFilterDrawer({
               </AccordionItem>
 
               {/* Language */}
-              <AccordionItem value="5" className={styles.sortSection}>
+              <AccordionItem
+                value="5"
+                className={`${styles.sortSection} ${styles.mainCategoryItem}`}
+              >
                 <AccordionHeader
                   expandIconPosition="end"
                   className={styles.accordionHeader}

--- a/src/components/gallery/MobileFilterDrawer/styles.module.css
+++ b/src/components/gallery/MobileFilterDrawer/styles.module.css
@@ -110,6 +110,11 @@
   margin-bottom: 12px;
 }
 
+/* Add spacing below main category accordion items only */
+.mainCategoryItem {
+  margin-bottom: 12px !important;
+}
+
 .accordionHeader {
   display: flex !important;
 

--- a/src/components/gallery/ShowcaseLeftFilters/index.tsx
+++ b/src/components/gallery/ShowcaseLeftFilters/index.tsx
@@ -293,8 +293,10 @@ export default function ShowcaseLeftFilters({
   const resourceTypeTag = TagList.filter((tag) => {
     const tagObject = Tags[tag];
     // Exclude standalone documentation sub-types (concepts, how-to, tutorial) since they appear under Documentation parent
-    return tagObject.type === "ResourceType" && 
-           !['concepts', 'how-to', 'tutorial'].includes(tag);
+    return (
+      tagObject.type === "ResourceType" &&
+      !["concepts", "how-to", "tutorial"].includes(tag)
+    );
   });
   const contentTypeTag = TagList.filter((tag) => {
     const tagObject = Tags[tag];
@@ -322,7 +324,7 @@ export default function ShowcaseLeftFilters({
       multiple
       collapsible
     >
-      <AccordionItem value="1">
+      <AccordionItem value="1" className={styles.mainCategoryItem}>
         <AccordionHeader
           expandIconPosition="end"
           className={styles.tagCatalogBackground}
@@ -348,7 +350,7 @@ export default function ShowcaseLeftFilters({
           />
         </AccordionPanel>
       </AccordionItem>
-      <AccordionItem value="2">
+      <AccordionItem value="2" className={styles.mainCategoryItem}>
         <AccordionHeader
           expandIconPosition="end"
           className={styles.tagCatalogBackground}
@@ -373,7 +375,7 @@ export default function ShowcaseLeftFilters({
           />
         </AccordionPanel>
       </AccordionItem>
-      <AccordionItem value="3">
+      <AccordionItem value="3" className={styles.mainCategoryItem}>
         <AccordionHeader
           expandIconPosition="end"
           className={styles.tagCatalogBackground}
@@ -398,7 +400,7 @@ export default function ShowcaseLeftFilters({
           />
         </AccordionPanel>
       </AccordionItem>
-      <AccordionItem value="4">
+      <AccordionItem value="4" className={styles.mainCategoryItem}>
         <AccordionHeader
           expandIconPosition="end"
           className={styles.tagCatalogBackground}
@@ -423,7 +425,7 @@ export default function ShowcaseLeftFilters({
           />
         </AccordionPanel>
       </AccordionItem>
-      <AccordionItem value="5">
+      <AccordionItem value="5" className={styles.mainCategoryItem}>
         <AccordionHeader expandIconPosition="end">
           <div
             className={styles.tagCatalog}

--- a/src/components/gallery/ShowcaseLeftFilters/styles.module.css
+++ b/src/components/gallery/ShowcaseLeftFilters/styles.module.css
@@ -72,3 +72,8 @@
   padding-top: 8px !important;
   padding-bottom: 12px !important;
 }
+
+/* Add spacing below main category accordion items only */
+.mainCategoryItem {
+  margin-bottom: 8px;
+}


### PR DESCRIPTION
Add consistent spacing below main category accordion items to improve layout in both the MobileFilterDrawer and ShowcaseLeftFilters components.